### PR TITLE
Fixed deprecated config option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ theme: minima
 
 permalink: /:year/:month/:day/:title/
 
-gems:
+plugins:
   - jekyll-feed
 exclude:
   - Gemfile


### PR DESCRIPTION
"Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly."